### PR TITLE
add aarch64 recognition for Linux

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -145,6 +145,8 @@ public final class SerialPort
 				if (linkerFile.exists())
 					libraryPath += "-hf";
 			}
+			else if (System.getProperty("os.arch").indexOf("aarch64") >= 0)
+				libraryPath = "Linux/armv8_64";
 			else if (System.getProperty("os.arch").indexOf("64") >= 0)
 				libraryPath = "Linux/x86_64";
 			else


### PR DESCRIPTION
This is needed for the aarch64 binary to be loaded. This is pretty much useless without #84 .