### PR TITLE
Add default value for system property 'os.arch_full'

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -120,7 +120,7 @@ public final class SerialPort
 		}
 		else if ((OS.indexOf("nix") >= 0) || (OS.indexOf("nux") >= 0))
 		{
-			if (!System.getProperty("os.arch_full").isEmpty())
+			if (!System.getProperty("os.arch_full", "").isEmpty())
 				libraryPath = "Linux/" + System.getProperty("os.arch_full").toLowerCase();
 			else if (System.getProperty("os.arch").indexOf("arm") >= 0)
 			{


### PR DESCRIPTION
`System.getProperty("os.arch_full")` returns `null` if there are no set property with name `os.arch_full`. 
Therefore, `System.getProperty("os.arch_full").isEmpty()` throws a `NullPointerException`.
To fix this, I've added an empty String as a default value: `System.getProperty("os.arch_full", "").isEmpty()`
