### PR TITLE
Check return value of ioctl `TIOCGSERIAL` on Linux

### DIFF
--- a/src/main/c/Posix/PosixHelperFunctions.c
+++ b/src/main/c/Posix/PosixHelperFunctions.c
@@ -510,13 +510,15 @@ int setBaudRateCustom(int portFD, baud_rate baudRate)
 	int retVal = ioctl(portFD, TCSETS2, &options);
 #else
 	struct serial_struct serInfo;
-	ioctl(portFD, TIOCGSERIAL, &serInfo);
-	serInfo.flags &= ~ASYNC_SPD_MASK;
-	serInfo.flags |= ASYNC_SPD_CUST | ASYNC_LOW_LATENCY;
-	serInfo.custom_divisor = serInfo.baud_base / baudRate;
-	if (sersInfo.custom_divisor == 0)
-		serInfo.custom_divisor = 1;
-	int retVal = ioctl(portFD, TIOCSSERIAL, &serInfo);
+	int retVal = ioctl(portFD, TIOCGSERIAL, &serInfo);
+	if (retVal == 0) {
+		serInfo.flags &= ~ASYNC_SPD_MASK;
+		serInfo.flags |= ASYNC_SPD_CUST | ASYNC_LOW_LATENCY;
+		serInfo.custom_divisor = serInfo.baud_base / baudRate;
+		if (sersInfo.custom_divisor == 0)
+			serInfo.custom_divisor = 1;
+		retVal = ioctl(portFD, TIOCSSERIAL, &serInfo);
+	}
 #endif
 	return (retVal == 0);
 }

--- a/src/main/c/Posix/SerialPort_Posix.c
+++ b/src/main/c/Posix/SerialPort_Posix.c
@@ -336,9 +336,11 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_configPort(J
 	// Attempt to set the transmit buffer size and any necessary custom baud rates
 #if defined(__linux__)
 	struct serial_struct serInfo;
-	ioctl(serialPortFD, TIOCGSERIAL, &serInfo);
-	serInfo.xmit_fifo_size = sendDeviceQueueSize;
-	ioctl(serialPortFD, TIOCSSERIAL, &serInfo);
+	int tiocgserialRetVal = ioctl(serialPortFD, TIOCGSERIAL, &serInfo);
+	if (tiocgserialRetVal == 0) {
+		serInfo.xmit_fifo_size = sendDeviceQueueSize;
+		ioctl(serialPortFD, TIOCSSERIAL, &serInfo);
+	}
 #endif
 	if (nonStandardBaudRate)
 		setBaudRateCustom(serialPortFD, baudRate);


### PR DESCRIPTION
In the fix for issue #153, the return value of the ioctl `TIOCGSERIAL` should be check to ensure that the `serInfo` variable has correctly been set before using it for `TIOCSSERIAL`.
Since Linux kernel 3.19, the `TIOCSSERIAL` ioctl prints a warning message when called (tty_warn_deprecated_flags). This behaviour will change in the next kernel version (4.20) but in the mean time this warning is spammed to the users.

In this PR, I check the return value of the `TIOCGSERIAL` ioctl which generates no warning. A return value not equal to 0 means that `TIOCGSERIAL` is not handled and `TIOCSSERIAL` is either not handled or generates a warning. When the return value is not 0, I skip the `TIOCSSERIAL` ioctl to avoid the warning.