### PR TITLE
Add remaining RS-485 configuration parameters for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ bin
 site
 build
 
+# Generated files for JNI
+src/main/c/com_fazecast_jSerialComm_SerialPort.h
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/src/main/c/Posix/Makefile
+++ b/src/main/c/Posix/Makefile
@@ -1,7 +1,7 @@
 # Architecture-dependent library variables
 COMPILE						:= gcc
-COMPILE_ARM32				:= arm32-unknown-linux-gnueabi-gcc
-COMPILE_ARM32HF				:= arm32hf-unknown-linux-gnueabi-gcc
+COMPILE_ARM32				:= arm-unknown-linux-gnueabi-gcc
+COMPILE_ARM32HF				:= arm-unknown-linux-gnueabihf-gcc
 COMPILE_ARM64				:= aarch64-unknown-linux-gnueabi-gcc
 COMPILE_PPC64LE				:= powerpc64le-unknown-linux-gnu-gcc
 COMPILE_SOLARIS_X86			:= x86_64-sun-solaris2.10-gcc

--- a/src/main/c/Posix/SerialPort_Posix.c
+++ b/src/main/c/Posix/SerialPort_Posix.c
@@ -66,6 +66,8 @@ jfieldID sendDeviceQueueSizeField;
 jfieldID receiveDeviceQueueSizeField;
 jfieldID rs485ModeField;
 jfieldID rs485ActiveHighField;
+jfieldID rs485EnableTerminationField;
+jfieldID rs485RxDuringTxField;
 jfieldID rs485DelayBeforeField;
 jfieldID rs485DelayAfterField;
 jfieldID timeoutModeField;
@@ -231,6 +233,8 @@ JNIEXPORT void JNICALL Java_com_fazecast_jSerialComm_SerialPort_initializeLibrar
 	receiveDeviceQueueSizeField = (*env)->GetFieldID(env, serialCommClass, "receiveDeviceQueueSize", "I");
 	rs485ModeField = (*env)->GetFieldID(env, serialCommClass, "rs485Mode", "Z");
 	rs485ActiveHighField = (*env)->GetFieldID(env, serialCommClass, "rs485ActiveHigh", "Z");
+	rs485EnableTerminationField = (*env)->GetFieldID(env, serialCommClass, "rs485EnableTermination", "Z");
+	rs485RxDuringTxField = (*env)->GetFieldID(env, serialCommClass, "rs485RxDuringTx", "Z");
 	rs485DelayBeforeField = (*env)->GetFieldID(env, serialCommClass, "rs485DelayBefore", "I");
 	rs485DelayAfterField = (*env)->GetFieldID(env, serialCommClass, "rs485DelayAfter", "I");
 	timeoutModeField = (*env)->GetFieldID(env, serialCommClass, "timeoutMode", "I");
@@ -321,6 +325,8 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_configPort(J
 	unsigned char configDisabled = (*env)->GetBooleanField(env, obj, disableConfigField);
 	unsigned char rs485ModeEnabled = (*env)->GetBooleanField(env, obj, rs485ModeField);
 	unsigned char rs485ActiveHigh = (*env)->GetBooleanField(env, obj, rs485ActiveHighField);
+	unsigned char rs485EnableTermination = (*env)->GetBooleanField(env, obj, rs485EnableTerminationField);
+	unsigned char rs485RxDuringTx = (*env)->GetBooleanField(env, obj, rs485RxDuringTxField);
 	unsigned char isDtrEnabled = (*env)->GetBooleanField(env, obj, isDtrEnabledField);
 	unsigned char isRtsEnabled = (*env)->GetBooleanField(env, obj, isRtsEnabledField);
 	tcflag_t byteSize = (byteSizeInt == 5) ? CS5 : (byteSizeInt == 6) ? CS6 : (byteSizeInt == 7) ? CS7 : CS8;
@@ -392,6 +398,22 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_configPort(J
 		{
 			rs485Conf.flags &= ~(SER_RS485_RTS_ON_SEND);
 			rs485Conf.flags |= SER_RS485_RTS_AFTER_SEND;
+		}
+		if (rs485RxDuringTx)
+		{
+			rs485Conf.flags |= SER_RS485_RX_DURING_TX;
+		}
+		else
+		{
+			rs485Conf.flags &= ~(SER_RS485_RX_DURING_TX);
+		}
+		if (rs485EnableTermination)
+		{
+			rs485Conf.flags |= SER_RS485_TERMINATE_BUS;
+		}
+		else
+		{
+			rs485Conf.flags &= ~(SER_RS485_TERMINATE_BUS);
 		}
 		// SerialPort defines delays in microseconds and Linux expects
 		// milliseconds (see

--- a/src/main/c/Posix/SerialPort_Posix.c
+++ b/src/main/c/Posix/SerialPort_Posix.c
@@ -393,8 +393,11 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_configPort(J
 			rs485Conf.flags &= ~(SER_RS485_RTS_ON_SEND);
 			rs485Conf.flags |= SER_RS485_RTS_AFTER_SEND;
 		}
-		rs485Conf.delay_rts_before_send = rs485DelayBefore;
-		rs485Conf.delay_rts_after_send = rs485DelayAfter;
+		// SerialPort defines delays in microseconds and Linux expects
+		// milliseconds (see
+		// https://github.com/torvalds/linux/blob/0c18f29aae7ce3dadd26d8ee3505d07cc982df75/include/uapi/linux/serial.h#L129).
+		rs485Conf.delay_rts_before_send = rs485DelayBefore / 1000;
+		rs485Conf.delay_rts_after_send = rs485DelayAfter / 1000;
 		ioctl(serialPortFD, TIOCSRS485, &rs485Conf);
 	}
 #endif

--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -394,7 +394,7 @@ public final class SerialPort
 	private volatile SerialPortEventListener serialEventListener = null;
 	private volatile String comPort, friendlyName, portDescription;
 	private volatile boolean eventListenerRunning = false, disableConfig = false, rs485Mode = false;
-	private volatile boolean rs485ActiveHigh = true, isRtsEnabled = true, isDtrEnabled = true;
+	private volatile boolean rs485ActiveHigh = true, rs485RxDuringTx = false, rs485EnableTermination = false, isRtsEnabled = true, isDtrEnabled = true;
 	private SerialPortInputStream inputStream = null;
 	private SerialPortOutputStream outputStream = null;
 
@@ -1167,29 +1167,55 @@ public final class SerialPort
 		return true;
 	}
 
+
 	/**
-	 * Sets whether to enable RS-485 mode for this device.
-	 * <p>
-	 * RS-485 mode can be used to enable transmit/receive mode signaling using the RTS pin. This mode should be set if you plan
-	 * to use this library with an RS-485 device. Note that this mode requires support from the underlying device driver, so it
-	 * may not work with all RS-485 devices.
-	 * <p>
-	 * The RTS "active high" parameter specifies that the logical level of the RTS line will be set to 1 when transmitting and
-	 * 0 when receiving.
-	 * <p>
-	 * The delay parameters specify how long to wait before or after transmission of data before enabling or disabling
-	 * transmission mode via the RTS pin.
+	 * Sets RS-485 mode and its parameters for the device. This is a wrapper around
+	 * {@link #setRs485ModeParameters(boolean, boolean, boolean, boolean, int, int)} for backward-compatibility which disables bus termination and
+	 * receiving data while transmitting.
+	 *
+	 * @see #setRs485ModeParameters(boolean, boolean, boolean, boolean, int, int)
 	 *
 	 * @param useRS485Mode Whether to enable RS-485 mode.
-	 * @param rs485RtsActiveHigh Whether to set the RTS line to 1 when transmitting.
-	 * @param delayBeforeSendMicroseconds The time to wait after enabling transmit mode before sending the first data bit.
-	 * @param delayAfterSendMicroseconds The time to wait after sending the last data bit before disabling transmit mode.
+	 * @param rs485RtsActiveHigh Whether to set the RTS line to 1 when transmitting (effective only on Linux).
+	 * @param delayBeforeSendMicroseconds The time to wait after enabling transmit mode before sending the first data bit (effective only on Linux).
+	 * @param delayAfterSendMicroseconds The time to wait after sending the last data bit before disabling transmit mode (effective only on Linux).
 	 * @return Whether the port configuration is valid or disallowed on this system (only meaningful after the port is already opened).
 	 */
 	public final synchronized boolean setRs485ModeParameters(boolean useRS485Mode, boolean rs485RtsActiveHigh, int delayBeforeSendMicroseconds, int delayAfterSendMicroseconds)
 	{
+		return setRs485ModeParameters(useRS485Mode, rs485RtsActiveHigh, false, false, delayBeforeSendMicroseconds, delayAfterSendMicroseconds);
+	}
+
+	/**
+	 * Sets RS-485 mode and its parameters for the device.
+	 * <p>
+	 * RS-485 mode can be used to enable transmit/receive mode signaling using the RTS pin. This mode should be set if you plan
+	 * to use this library with an RS-485 device. Note that this mode requires support from the underlying device and device
+	 * driver, so it may not work with all RS-485 devices. On the other hand there are devices with operate in RS-485 mode by
+	 * default and do not require explicit configuration (like some USB to RS-485 adapters).
+	 * <p>
+	 * Please note that the parameters beyond <i>useRS485Mode</i> are only effective on Linux.
+	 * <p>
+	 * The RTS "active high" parameter specifies that the logical level of the RTS line will be set to 1 when transmitting and
+	 * 0 when receiving or the other way around.
+	 * <p>
+	 * The delay parameters specify how long to wait before or after transmission of data after enabling or before disabling
+	 * transmission mode via the RTS pin.
+	 *
+	 * @param useRS485Mode Whether to enable RS-485 mode.
+	 * @param rs485RtsActiveHigh Whether to set the RTS line to 1 when transmitting (effective only on Linux).
+	 * @param enableTermination Whether to enable RS-485 bus termination on systems supporting this feature (effective only on Linux).
+	 * @param rxDuringTx Whether to receive data while transmitting. This usually means that data sent will be read back (effective only on Linux).
+	 * @param delayBeforeSendMicroseconds The time to wait after enabling transmit mode before sending the first data bit (effective only on Linux).
+	 * @param delayAfterSendMicroseconds The time to wait after sending the last data bit before disabling transmit mode (effective only on Linux).
+	 * @return Whether the port configuration is valid or disallowed on this system (only meaningful after the port is already opened).
+	 */
+	public final synchronized boolean setRs485ModeParameters(boolean useRS485Mode, boolean rs485RtsActiveHigh, boolean enableTermination, boolean rxDuringTx, int delayBeforeSendMicroseconds, int delayAfterSendMicroseconds)
+	{
 		rs485Mode = useRS485Mode;
 		rs485ActiveHigh = rs485RtsActiveHigh;
+		rs485EnableTermination = enableTermination;
+		rs485RxDuringTx = rxDuringTx;
 		rs485DelayBefore = delayBeforeSendMicroseconds;
 		rs485DelayAfter = delayAfterSendMicroseconds;
 


### PR DESCRIPTION
This PR adds the two remaining configuration parameters from the [`TIOCSRS485`](https://github.com/torvalds/linux/blob/e9f1cbc0c4114880090c7a578117d3b9cf184ad4/include/uapi/linux/serial.h#L110) ioctl to the already existing ones:

- Enabling bus termination on hardware which supports it
- Enabling receiving data while transmitting (for example for checking for colissions)

Having them accessible via the jSerialComms Java interface facilitates working with RS-485 interfaces on Linux to the full extent. They might also come in handy when working around issues with certain device drivers.

This PR depends on #353.

I've successfully tested both parameters with Kernel 5.12/ARM. In lack of hardware supporting bus termination, I just checked whether the flag got set and cleared.

What is still missing:
- [ ] Building the native libraries for all platforms