### PR TITLE
Use SerialPort with try-with-resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,8 @@ if (hasProperty('manualBuild'))
   assert hasProperty('java9Home'): "Set the property 'java9Home' in your gradle.properties file pointing to a Java 9 JDK installation"
 }
 
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
 javadoc.options.links("https://docs.oracle.com/javase/9/docs/api/")
 javadoc.options.addBooleanOption('html4', true)
 

--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -47,7 +47,7 @@ import java.util.Date;
  * @see java.io.InputStream
  * @see java.io.OutputStream
  */
-public final class SerialPort
+public final class SerialPort implements AutoCloseable
 {
 	// Static initializer loads correct native library for this machine
 	static private final String versionString = "2.8.0";
@@ -615,6 +615,14 @@ public final class SerialPort
 				portHandle = closePortNative(portHandle);
 			return (portHandle <= 0);
         }
+	}
+
+	@Override
+	public void close() throws SerialPortIOException
+	{
+		if (!closePort()) {
+			throw new SerialPortIOException("Failed to close");
+		}
 	}
 
 	/**


### PR DESCRIPTION
Let the `SerialPort` implement `AutoCloseable`. This requires bumping
minimal required Java version to 7.