### PR TITLE
Fix thrown exceptions from getCommPort

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -420,7 +420,7 @@ public final class SerialPort
 	 * @return A {@link SerialPort} object.
 	 * @throws SerialPortInvalidPortException If a {@link SerialPort} object cannot be created due to a logical or formatting error in the portDescriptor parameter.
 	 */
-	static public final SerialPort getCommPort(String portDescriptor) throws SerialPortInvalidPortException
+	static public final SerialPort getCommPort(String portDescriptor) throws SerialPortInvalidPortException, IOException
 	{
 		// Correct port descriptor, if needed
 		try

--- a/src/test/java/com/fazecast/jSerialComm/SerialPortTest.java
+++ b/src/test/java/com/fazecast/jSerialComm/SerialPortTest.java
@@ -25,6 +25,7 @@
 
 package com.fazecast.jSerialComm;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
 
@@ -81,7 +82,7 @@ public class SerialPortTest
 		public boolean delimiterIndicatesEndOfMessage() { return false; }
 	}
 
-	static public void main(String[] args)
+	static public void main(String[] args) throws SerialPortInvalidPortException, IOException
 	{
 		System.out.println("\nUsing Library Version v" + SerialPort.getVersion());
 		SerialPort[] ports = SerialPort.getCommPorts();


### PR DESCRIPTION
Currently it's quite complicated to call `getCommPort()`:
```java
try {
  [...].getCommPort()
} catch (SerialPortInvalidPortException e) {
  // handle exception
}
```
doesn't handle `IOException`, but adding this Exception to the catch block isn't accepted by java because the method signature lacks the corresponding `throws` notation. It is possible though to handle it like this:
```
[...]
} catch (SerialPortInvalidPortException e) {
  // handle exception
} catch (Exception e) {
  if (e instanceof IOExecption)
  // handle ioexecption
}
```
but this is kind of ugly.

I propose to add the missing `throws IOException` to the method signature, what do you think? 