### PR TITLE
Removes the final modifier from SerialPort

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -49,7 +49,7 @@ import java.util.Vector;
  * @see java.io.OutputStream
  */
 @SuppressWarnings("unused")
-public final class SerialPort
+public class SerialPort
 {
 	// Parity Values
 	static final public int NO_PARITY = 0;


### PR DESCRIPTION
Removes the final modifier from SerialPort. This class only has a private constructor which makes it effectively final. Also, removing the final modifier allows for easier mocking for unit testing.