### PR TITLE
Add method to set DTR and RTS together

### DIFF
--- a/src/main/c/Posix/SerialPort_Posix.c
+++ b/src/main/c/Posix/SerialPort_Posix.c
@@ -1141,6 +1141,33 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_clearDTR(JNI
 	return JNI_TRUE;
 }
 
+JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_setDTRandRTS(JNIEnv *env, jobject obj, jlong serialPortPointer, jboolean dtr, jboolean rts)
+{
+  struct serialPort *port = (serialPort*)(intptr_t)serialPortPointer;
+  int status;
+
+  // Read current status
+  if (ioctl(port->handle, TIOCMGET, &status)) {
+    port->errorNumber = errno;
+    return JNI_FALSE;
+  }
+
+  // Modify bits
+  if (dtr) status |= TIOCM_DTR;
+  else     status &= ~TIOCM_DTR;
+
+  if (rts) status |= TIOCM_RTS;
+  else     status &= ~TIOCM_RTS;
+
+  // Write combined status
+  if (ioctl(port->handle, TIOCMSET, &status)) {
+    port->errorNumber = errno;
+    return JNI_FALSE;
+  }
+
+  return JNI_TRUE;
+}
+
 JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_getCTS(JNIEnv *env, jobject obj, jlong serialPortPointer)
 {
 	int modemBits = 0;

--- a/src/main/c/Posix/com_fazecast_jSerialComm_SerialPort.h
+++ b/src/main/c/Posix/com_fazecast_jSerialComm_SerialPort.h
@@ -237,6 +237,14 @@ JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_clearDTR
 
 /*
  * Class:     com_fazecast_jSerialComm_SerialPort
+ * Method:    setDTRandRTS
+ * Signature: (JZZ)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_fazecast_jSerialComm_SerialPort_setDTRandRTS
+  (JNIEnv *, jobject, jlong, jboolean, jboolean);
+
+/*
+ * Class:     com_fazecast_jSerialComm_SerialPort
  * Method:    getCTS
  * Signature: (J)Z
  */

--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -852,6 +852,7 @@ public class SerialPort
 	private native boolean clearRTS(long portHandle);					// Clear RTS line to 0
 	private native boolean setDTR(long portHandle);						// Set DTR line to 1
 	private native boolean clearDTR(long portHandle);					// Clear DTR line to 0
+    private native boolean setDTRandRTS(long portHandle, boolean dtr, boolean rts);
 	private native boolean getCTS(long portHandle);						// Returns whether the CTS signal is 1
 	private native boolean getDSR(long portHandle);						// Returns whether the DSR signal is 1
 	private native boolean getDCD(long portHandle);						// Returns whether the DCD signal is 1
@@ -1061,7 +1062,21 @@ public class SerialPort
 		return (androidPort != null) ? androidPort.clearDTR() : ((portHandle == 0) || clearDTR(portHandle));
 	}
 
-	/**
+  /**
+   * Sets the DTR and RTS lines to the specified values.
+   * @param dtr - the desired state of the DTR line.
+   * @param rts - the desired state of the RTS line.
+   * @return true if successful, false if not.
+   */
+  public final boolean setDTRandRTS(boolean dtr, boolean rts)
+  {
+    isDtrEnabled = dtr;
+    isRtsEnabled = rts;
+    return (androidPort != null) ? androidPort.setDTRandRTS(dtr, rts) : ((portHandle == 0) || setDTRandRTS(portHandle, dtr, rts));
+  }
+
+
+  /**
 	 * Returns whether the CTS line is currently asserted.
 	 * @return Whether or not the CTS line is asserted.
 	 */

--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -1065,9 +1065,9 @@ public class SerialPort
 	/**
 	 * Sets the DTR and RTS lines to the specified values.
 	 * @param dtr - the desired state of the DTR line.
-	* @param rts - the desired state of the RTS line.
-	* @return true if successful, false if not.
-	*/
+	 * @param rts - the desired state of the RTS line.
+	 * @return true if successful, false if not.
+	 */
 	public final boolean setDTRandRTS(boolean dtr, boolean rts)
 	{
 		isDtrEnabled = dtr;

--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -852,7 +852,7 @@ public class SerialPort
 	private native boolean clearRTS(long portHandle);					// Clear RTS line to 0
 	private native boolean setDTR(long portHandle);						// Set DTR line to 1
 	private native boolean clearDTR(long portHandle);					// Clear DTR line to 0
-    private native boolean setDTRandRTS(long portHandle, boolean dtr, boolean rts);
+	private native boolean setDTRandRTS(long portHandle, boolean dtr, boolean rts);
 	private native boolean getCTS(long portHandle);						// Returns whether the CTS signal is 1
 	private native boolean getDSR(long portHandle);						// Returns whether the DSR signal is 1
 	private native boolean getDCD(long portHandle);						// Returns whether the DCD signal is 1
@@ -1062,21 +1062,20 @@ public class SerialPort
 		return (androidPort != null) ? androidPort.clearDTR() : ((portHandle == 0) || clearDTR(portHandle));
 	}
 
-  /**
-   * Sets the DTR and RTS lines to the specified values.
-   * @param dtr - the desired state of the DTR line.
-   * @param rts - the desired state of the RTS line.
-   * @return true if successful, false if not.
-   */
-  public final boolean setDTRandRTS(boolean dtr, boolean rts)
-  {
-    isDtrEnabled = dtr;
-    isRtsEnabled = rts;
-    return (androidPort != null) ? androidPort.setDTRandRTS(dtr, rts) : ((portHandle == 0) || setDTRandRTS(portHandle, dtr, rts));
-  }
+	/**
+	 * Sets the DTR and RTS lines to the specified values.
+	 * @param dtr - the desired state of the DTR line.
+	* @param rts - the desired state of the RTS line.
+	* @return true if successful, false if not.
+	*/
+	public final boolean setDTRandRTS(boolean dtr, boolean rts)
+	{
+		isDtrEnabled = dtr;
+		isRtsEnabled = rts;
+		return (androidPort != null) ? androidPort.setDTRandRTS(dtr, rts) : ((portHandle == 0) || setDTRandRTS(portHandle, dtr, rts));
+	}
 
-
-  /**
+	 /**
 	 * Returns whether the CTS line is currently asserted.
 	 * @return Whether or not the CTS line is asserted.
 	 */

--- a/src/main/java/com/fazecast/jSerialComm/android/AndroidPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/android/AndroidPort.java
@@ -219,7 +219,7 @@ public abstract class AndroidPort
 	public abstract boolean clearRTS();
 	public abstract boolean setDTR();
 	public abstract boolean clearDTR();
-    public abstract boolean setDTRandRTS(boolean dtr, boolean rts);
+	public abstract boolean setDTRandRTS(boolean dtr, boolean rts);
 	public abstract boolean getCTS();
 	public abstract boolean getDSR();
 	public abstract boolean getDCD();

--- a/src/main/java/com/fazecast/jSerialComm/android/AndroidPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/android/AndroidPort.java
@@ -219,6 +219,7 @@ public abstract class AndroidPort
 	public abstract boolean clearRTS();
 	public abstract boolean setDTR();
 	public abstract boolean clearDTR();
+    public abstract boolean setDTRandRTS(boolean dtr, boolean rts);
 	public abstract boolean getCTS();
 	public abstract boolean getDSR();
 	public abstract boolean getDCD();


### PR DESCRIPTION
This PR adds a method to set both DTR and RTS control lines in a single call:
```
setDTRandRTS(boolean dtr, boolean rts)
```
#### Why

Some USB-to-serial adapters (e.g. **CP2102**) require DTR and RTS to be set together in the same USB control transfer. When set separately, these adapters change GPIOs at different times, which makes it impossible to reliably reset or enter bootloader mode on devices like the **ESP32**.

#### What’s Changed

* New native method for setting DTR and RTS together
* Works on Windows and POSIX
* Exposed through `SerialPort.java`
* Does not change or break any existing APIs

#### Benefits

* Reliable ESP32 bootloader support with more USB adapters
* Better control over DTR/RTS timing
* Optional for users who need it

