### PR TITLE
Fix the error message for invalid port

### DIFF
--- a/src/main/java/com/fazecast/jSerialComm/SerialPort.java
+++ b/src/main/java/com/fazecast/jSerialComm/SerialPort.java
@@ -511,6 +511,7 @@ public class SerialPort
 
 		// Correct port descriptor, if needed
 		libraryLock.lock();
+		final String originalPortDescriptor = portDescriptor;
 		try
 		{
 			// Resolve home directory ~
@@ -546,7 +547,7 @@ public class SerialPort
 			serialPort.retrievePortDetails();
 			return serialPort;
 		}
-		catch (Exception e) { throw new SerialPortInvalidPortException("Unable to create a serial port object from the invalid port descriptor: " + portDescriptor, e); }
+		catch (Exception e) { throw new SerialPortInvalidPortException("Unable to create a serial port object from the invalid port descriptor: " + originalPortDescriptor, e); }
 		finally { libraryLock.unlock(); }
 	}
 


### PR DESCRIPTION
when an invalid port path was provided, the exception message showed the resolved path instead of the user’s original input, which could cause confusion.


```java
    @Test
    public void test() throws InterruptedException {
        SerialPort.getCommPort("/tmp/tty.usbserial-1310");
    }
```
```log
com.fazecast.jSerialComm.SerialPortInvalidPortException: 
Unable to create a serial port object from the invalid port descriptor: /dev/tty.usbserial-1310

	at com.fazecast.jSerialComm.SerialPort.getCommPort(SerialPort.java:549)
	at SerialPortTest.test(SerialPortTest.java:93)
```