### PR TITLE
feat(android): support Android S+ pending intent flags and clean imports

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,4 @@
 module com.fazecast.jSerialComm {
-	exports com.fazecast.jSerialComm;
+    requires android;
+    exports com.fazecast.jSerialComm;
 }


### PR DESCRIPTION
Ensure Android USB enumeration safely handles modern Android requirements:
- add android module requirement in module-info
- import android.os.Build and replace specific HashMap import with a wildcard
- set PendingIntent flags for Android S (SDK 31) and above (use FLAG_MUTABLE) to avoid Broadcast PendingIntent issues on newer platforms
- attach permission intent to the app package and register receiver with a clear intent filter
- simplify and harden context and USB feature checks; preserve empty result when USB host feature is absent

These changes fix runtime failures on Android 12+ when requesting USB permissions and tidy imports for portability.