### PR TITLE
Fix global JNI class references

### DIFF
--- a/src/main/c/Windows/SerialPort_Windows.c
+++ b/src/main/c/Windows/SerialPort_Windows.c
@@ -43,8 +43,8 @@
 #include "WindowsHelperFunctions.h"
 
 // Cached class, method, and field IDs
-jclass serialCommClass;
-jclass jniErrorClass;
+jclass serialCommClass = NULL;
+jclass jniErrorClass = NULL;
 jmethodID serialCommConstructor;
 jfieldID serialPortHandleField;
 jfieldID comPortField;


### PR DESCRIPTION
`FindClass` returns a local object reference, these references should be made global in order to avoid garbage collection. May fix crashing on some PCs when enumerating COM ports.

The local reference started to be used globally since <https://github.com/Fazecast/jSerialComm/commit/0d186694058ea0a79ec6a35bd54ea40e62754837>, which appears to be the source of crashing.
See also: https://www.ibm.com/docs/en/sdk-java-technology/8?topic=collector-overview-jni-object-references

This PR initializes the jclass references to `NULL`, uses `NewGlobalRef` to make the serial comm and jni error classes global references, and uses `DeleteGlobalRef` when unloaded to destroy these references.

I have not been able to test these changes with someone who experienced crashes yet, but I can likely find someone within the next month or two. I have run it on my own computer and it functions as expected.