### PR TITLE
Fix testPollPosix to work with changes from #54bd919

### DIFF
--- a/src/test/c/testPollPosix.c
+++ b/src/test/c/testPollPosix.c
@@ -92,7 +92,7 @@ int configPort(serialPort *port)
 	// Apply changes
 	if (fcntl(port->handle, F_SETFL, flags))
 		return 0;
-	if (setConfigOptions(port->handle, baudRate, &options))
+	if (setCustomBaudRate(port->handle, baudRate))
 		return 0;
 	return 1;
 }


### PR DESCRIPTION
In #54bd919 the function setConfigOptions was replaced with setCustomBaudRate.

This PR updates the testPollPosix test to call setCustomBaudRate.

Heiko