### PR TITLE
Fix bluetooth and relative symlinks

### DIFF
--- a/src/test/c/testPollPosix.c
+++ b/src/test/c/testPollPosix.c
@@ -92,7 +92,7 @@ int configPort(serialPort *port)
 	// Apply changes
 	if (fcntl(port->handle, F_SETFL, flags))
 		return 0;
-	if (setConfigOptions(port->handle, baudRate, &options))
+	if (setCustomBaudRate(port->handle, baudRate))
 		return 0;
 	return 1;
 }


### PR DESCRIPTION
This includes the changes from #615.

It should fix #567 for relative links and links to bluetooth devices as well.